### PR TITLE
Thêm chức năng tra cứu lịch sử giao dịch

### DIFF
--- a/include/controllers/WalletController.hpp
+++ b/include/controllers/WalletController.hpp
@@ -28,6 +28,11 @@ class WalletController {
 
   // In ra danh sách ví
   static void printListWallet();
+ // kiểm tra có phải ID ví của người dùng không
+  static bool isWalletOwnedByUser(int userId, int walletId);
+// hàm gọi tên uesr
+  static std::optional<int> getOwnerIdByWalletId(int walletId);
+  static std::string        getOwnerNameByWalletId(int walletId);
 };
 
 }  // namespace controllers

--- a/include/services/TransactionHistory.hpp
+++ b/include/services/TransactionHistory.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include "enums/Enums.hpp"
+#include "utils/Storage.hpp"
+
+using json = nlohmann::json;
+
+namespace services {
+
+// Bộ lọc truy vấn
+struct TxQuery {
+  // "all" | "incoming" | "outgoing"
+  std::string direction = "all";
+  // lọc theo trạng thái (để trống = bỏ qua)
+  std::optional<enums::TransactionStatus> status;
+  // lọc theo khoảng số tiền
+  std::optional<double> minAmount;
+  std::optional<double> maxAmount;
+  // sắp xếp: "id_asc" | "id_desc"
+  std::string sort = "id_desc";
+  // phân trang
+  int page = 1;
+  int pageSize = 20;
+};
+
+// Chỉ phụ trách TRUY VẤN lịch sử từ data/transactions.json
+class TransactionHistory {
+ public:
+  explicit TransactionHistory(std::string dataFile = "data/transactions.json");
+
+  // Danh sách toàn bộ giao dịch của 1 ví (mặc định sắp xếp id_desc)
+  std::vector<json> listByWallet(int walletId) const;
+
+  // Truy vấn nâng cao theo bộ lọc
+  std::vector<json> queryByWallet(int walletId, const TxQuery& q) const;
+
+ private:
+  std::string dataFile_;
+
+  // Helpers
+  json readAll() const;
+  static bool passDirection(int walletId, const json& tx, const std::string& dir);
+};
+
+}  // namespace services

--- a/include/utils/Utf8Console.hpp
+++ b/include/utils/Utf8Console.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include <string>
+#include <iostream>
+
+#ifdef _WIN32
+  #include <windows.h>
+#endif
+
+namespace vnconsole {
+
+/* ===========================
+   Console UTF-8 (Windows only)
+   =========================== */
+inline void initVietnameseConsole() {
+#ifdef _WIN32
+    // Đặt code page cho I/O là UTF-8
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+
+    // Bật VT processing để xử lý Unicode tốt hơn (Windows 10+)
+    if (HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE)) {
+        DWORD mode = 0;
+        if (GetConsoleMode(hOut, &mode)) {
+            mode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+            SetConsoleMode(hOut, mode);
+        }
+    }
+    // Không đổi _setmode -> tiếp tục in bằng std::cout (UTF-8)
+#endif
+}
+
+// In UTF-8 qua std::cout (portable)
+inline void print(const std::string& utf8) {
+    std::cout << utf8;
+}
+
+// In wstring trực tiếp (khi bạn thật sự cần wide)
+inline void wprint(const std::wstring& w) {
+#ifdef _WIN32
+    DWORD written = 0;
+    WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE),
+                  w.c_str(), (DWORD)w.size(), &written, nullptr);
+#else
+    std::wcout << w;
+#endif
+}
+
+/* =======================================
+   UTF-8 helpers cho căn cột/bảng trong console
+   (đếm theo số ký tự Unicode, không phải byte)
+   ======================================= */
+
+// Đếm số code point trong chuỗi UTF-8 (đủ cho tiếng Việt thường dùng)
+inline size_t utf8_length(const std::string& s) {
+    size_t count = 0;
+    for (size_t i = 0; i < s.size();) {
+        unsigned char c = static_cast<unsigned char>(s[i]);
+        if ((c & 0x80) == 0)        i += 1; // 0xxxxxxx
+        else if ((c & 0xE0) == 0xC0) i += 2; // 110xxxxx
+        else if ((c & 0xF0) == 0xE0) i += 3; // 1110xxxx
+        else if ((c & 0xF8) == 0xF0) i += 4; // 11110xxx
+        else                         i += 1; // fallback
+        ++count;
+    }
+    return count;
+}
+
+// Pad phải (left = true) hoặc pad trái (left = false) theo số ký tự Unicode
+inline std::string utf8_pad(const std::string& s, size_t width, bool left = true) {
+    size_t len = utf8_length(s);
+    if (len >= width) return s;
+    size_t spaces = width - len;
+    return left ? (s + std::string(spaces, ' '))
+                : (std::string(spaces, ' ') + s);
+}
+
+// Tiện dụng: pad trái/phải rõ ràng
+inline std::string pad_left (const std::string& s, size_t width)  { return utf8_pad(s, width, false); }
+inline std::string pad_right(const std::string& s, size_t width)  { return utf8_pad(s, width, true ); }
+
+} // namespace vnconsole

--- a/include/views/AdminView.hpp
+++ b/include/views/AdminView.hpp
@@ -14,7 +14,7 @@ class AdminView {
   void handleCreateAccount();
   void handleViewAllUsers();
   void handleViewAllWallets();
-  void handleViewTransactionHistory();
+  void handleSearchTransactions();
   void handleEditUserInfo();
   void handleManageTotalWallet();
   void handleChangePassword();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,16 +1,17 @@
 #include <iostream>
-
-using namespace std;
-
+#include "utils/Utf8Console.hpp"
 #include "models/User.hpp"
 #include "seeds/MySeed.hpp"
 #include "views/MainView.hpp"
-
+using namespace std;
 int main() {
   seeds::Seed::initialize();
 
   views::MainView mainView;
   mainView.display();
 
+ // Bật UTF-8 cho console (Windows)
+  vnconsole::initVietnameseConsole();
+  
   return 0;
 }

--- a/src/services/TransactionHistory.cpp
+++ b/src/services/TransactionHistory.cpp
@@ -1,0 +1,90 @@
+#include "services/TransactionHistory.hpp"
+#include <algorithm>
+
+using services::TransactionHistory;
+
+// Phòng khi chưa có macro (ví dụ build tool lạ)
+#ifndef DATA_DIR
+#define DATA_DIR "data"
+#endif
+
+TransactionHistory::TransactionHistory(std::string dataFile)
+    : dataFile_(std::move(dataFile)) {
+  if (dataFile_.empty()) {
+    dataFile_ = std::string(DATA_DIR) + "/transactions.json";
+  }
+}
+
+json TransactionHistory::readAll() const {
+  json arr = utils::storage::readJsonFile(dataFile_);
+  if (!arr.is_array()) return json::array();
+  return arr;
+}
+
+bool TransactionHistory::passDirection(int walletId, const json& tx, const std::string& dir) {
+  int src = tx.value("sourceWalletId", -1);
+  int dst = tx.value("destinationWalletId", -1);
+  if (dir == "all") return (src == walletId) || (dst == walletId);
+  if (dir == "outgoing") return src == walletId;
+  if (dir == "incoming") return dst == walletId;
+  return (src == walletId) || (dst == walletId);
+}
+
+std::vector<json> TransactionHistory::listByWallet(int walletId) const {
+  json all = readAll();
+  std::vector<json> out;
+  out.reserve(all.size());
+  for (const auto& tx : all) {
+    if (!tx.is_object()) continue;
+    int src = tx.value("sourceWalletId", -1);
+    int dst = tx.value("destinationWalletId", -1);
+    if (src == walletId || dst == walletId) out.push_back(tx);
+  }
+  std::sort(out.begin(), out.end(), [](const json& a, const json& b){
+    return a.value("id", 0) > b.value("id", 0);
+  });
+  return out;
+}
+
+std::vector<json> TransactionHistory::queryByWallet(int walletId, const services::TxQuery& q) const {
+  json all = readAll();
+  std::vector<json> out;
+  out.reserve(all.size());
+
+  for (const auto& tx : all) {
+    if (!tx.is_object()) continue;
+
+    if (!passDirection(walletId, tx, q.direction)) continue;
+
+    if (q.status.has_value()) {
+      int st = tx.value("status", -1);
+      if (st != static_cast<int>(*q.status)) continue;
+    }
+
+    double amount = tx.value("amount", 0.0);
+    if (q.minAmount.has_value() && amount < *q.minAmount) continue;
+    if (q.maxAmount.has_value() && amount > *q.maxAmount) continue;
+
+    out.push_back(tx);
+  }
+
+  // sort
+  if (q.sort == "id_asc") {
+    std::sort(out.begin(), out.end(), [](const json& a, const json& b){
+      return a.value("id", 0) < b.value("id", 0);
+    });
+  } else { // id_desc
+    std::sort(out.begin(), out.end(), [](const json& a, const json& b){
+      return a.value("id", 0) > b.value("id", 0);
+    });
+  }
+
+  // paging
+  int page = std::max(1, q.page);
+  int ps   = std::max(1, q.pageSize);
+  size_t start = static_cast<size_t>((page - 1) * ps);
+  if (start >= out.size()) return {};
+  size_t end = std::min(out.size(), start + static_cast<size_t>(ps));
+  return std::vector<json>(out.begin() + static_cast<long>(start),
+                           out.begin() + static_cast<long>(end));
+}

--- a/src/views/AdminView.cpp
+++ b/src/views/AdminView.cpp
@@ -200,8 +200,31 @@ void AdminView::handleViewAllWallets() {
 }
 
 /**
- * @brief Hiển thị chức năng tra cứu các giao dịch của các ví
+ * @brief Tra cứu lịch sử giao dịch (dành cho ADMIN).
  *
+ * Input:
+ *  - Wallet ID do admin nhập từ bàn phím.
+ *    + Nếu nhập "all" → hiển thị toàn bộ giao dịch của tất cả ví.
+ *    + Nếu nhập số hợp lệ → hiển thị giao dịch liên quan đến ví đó.
+ *
+ * Output:
+ *  - Hiển thị bảng lịch sử giao dịch ra màn hình.
+ *  - Nếu là 1 ví cụ thể → hiển thị thêm số dư hiện tại của ví đó.
+ *
+ * Thủ tục xử lý:
+ *  1. Hiển thị tiêu đề "TRA CỨU LỊCH SỬ GIAO DỊCH (ADMIN)".
+ *  2. Yêu cầu admin nhập Wallet ID hoặc "all".
+ *  3. Nếu "all":
+ *      - Lấy danh sách tất cả các ví.
+ *      - Truy vấn và gộp toàn bộ giao dịch (loại bỏ liệt kê duuplicate do 1 giao dịch sẽ được ghi nhận 2 lần: 1 chuyển điểm và 1 nhận điểm).
+ *      - Sắp xếp giảm dần theo ID và hiển thị bảng (STT, Từ người dùng, Đến người dùng, Số điểm).
+ *  4. Nếu nhập Wallet ID cụ thể:
+ *      - Kiểm tra hợp lệ.
+ *      - Truy vấn giao dịch của ví đó, sắp xếp giảm dần theo ID.
+ *      - Hiển thị bảng (STT, Từ người dùng, Đến người dùng, Số điểm).
+ *      - Lấy thêm số dư hiện tại của ví từ WalletController và in ra màn hình.
+ *  5. Nếu không có giao dịch nào → thông báo và dừng.
+ *  6. Tạm dừng chờ người dùng nhấn phím tiếp tục.
  */
 void AdminView::handleSearchTransactions() {
   utils::MessageHandler::logMessage("┌─────────────────────────────────────────────┐");

--- a/src/views/AdminView.cpp
+++ b/src/views/AdminView.cpp
@@ -1,17 +1,23 @@
 #include "views/AdminView.hpp"
-
+#include <filesystem>
+#include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <sstream>
-
+#include <unordered_map>
+#include <unordered_set>
+#include <tuple>
+#include "services/TransactionHistory.hpp"  
 #include "controllers/AuthController.hpp"
 #include "controllers/LogController.hpp"
 #include "controllers/TransactionController.hpp"
 #include "controllers/WalletController.hpp"
 #include "utils/Input.hpp"
 #include "utils/MessageHandler.hpp"
+#include "services/UserService.hpp"
+#include "utils/Utf8Console.hpp"
 
 namespace views {
 
@@ -85,7 +91,7 @@ void AdminView::display() {
         handleViewAllWallets();  // Xem danh sách ví
         break;
       case 3:
-        handleViewTransactionHistory();  // Xem lịch sử giao dịch
+        handleSearchTransactions();// Xem lịch sử giao dịch
         break;
       case 4:
         handleCreateAccount();  // Tạo tài khoản mới
@@ -194,12 +200,178 @@ void AdminView::handleViewAllWallets() {
 }
 
 /**
- * @brief Hiển thị lịch sử giao dịch (đang phát triển).
+ * @brief Hiển thị chức năng tra cứu các giao dịch của các ví
  *
- * Input/Output: Hiện tại chỉ thông báo chức năng đang phát triển.
  */
-void AdminView::handleViewTransactionHistory() {
-  utils::MessageHandler::logMessage("Chức năng đang được phát triển...");
+void AdminView::handleSearchTransactions() {
+  utils::MessageHandler::logMessage("┌─────────────────────────────────────────────┐");
+  utils::MessageHandler::logMessage("│      TRA CỨU LỊCH SỬ GIAO DỊCH (ADMIN)      │");
+  utils::MessageHandler::logMessage("└─────────────────────────────────────────────┘");
+
+  std::string key = utils::input::getInput("Nhập Wallet ID (gõ 'all' để xem tất cả): ");
+
+  services::TxQuery query;
+  query.direction = "all";
+  query.sort      = "id_desc";
+  services::TransactionHistory history;
+
+  // Cache tên user theo walletId
+  std::unordered_map<int, std::string> nameCache;
+  auto fullNameOfWallet = [&](int wid) -> const std::string& {
+    auto it = nameCache.find(wid);
+    if (it != nameCache.end()) return it->second;
+
+    std::string name = "Unknown";
+    if (auto ownerId = controllers::WalletController::getOwnerIdByWalletId(wid)) {
+      if (auto u = services::UserService::findUserById(*ownerId)) {
+        name = u->value("fullName", "user#" + std::to_string(*ownerId));
+      } else {
+        name = "user#" + std::to_string(*ownerId);
+      }
+    } else {
+      name = "W#" + std::to_string(wid);
+    }
+    return nameCache.emplace(wid, std::move(name)).first->second;
+  };
+
+  // ===== cấu hình bảng + helpers in header/footer =====
+  constexpr int W_STT  = 3;
+  constexpr int W_FROM = 20;
+  constexpr int W_TO   = 20;
+  constexpr int W_AMT  = 12;
+
+  auto make_hline = [=]() {
+    return std::string("+")
+      + std::string(static_cast<std::size_t>(W_STT  + 2), '-') + "+"
+      + std::string(static_cast<std::size_t>(W_FROM + 2), '-') + "+"
+      + std::string(static_cast<std::size_t>(W_TO   + 2), '-') + "+"
+      + std::string(static_cast<std::size_t>(W_AMT  + 2), '-') + "+";
+  };
+
+  auto printHeader = [&]() {
+    utils::MessageHandler::logMessage(make_hline());
+    std::ostringstream hdr;
+    hdr << "| " << vnconsole::pad_right("STT",            W_STT)
+        << " | " << vnconsole::pad_right("Từ người dùng",  W_FROM)
+        << " | " << vnconsole::pad_right("Đến người dùng", W_TO)
+        << " | " << vnconsole::pad_right("Số điểm",        W_AMT)
+        << " |";
+    utils::MessageHandler::logMessage(hdr.str());
+    utils::MessageHandler::logMessage(make_hline());
+  };
+
+  auto printFooter = [&]() { utils::MessageHandler::logMessage(make_hline()); };
+
+  // ================== CHẾ ĐỘ ALL (khử trùng theo id) ==================
+  if (key == "all" || key == "ALL" || key == "All") {
+    auto wallets = controllers::WalletController::getAllWallets();
+
+    struct Row { int id; int src; int dst; double amt; };
+    std::vector<Row> rowsAll;
+    std::unordered_set<int> seenIds;
+
+    for (const auto& w : wallets) {
+      int wid = w.getId();                         // đổi getter nếu khác tên
+      auto rows = history.queryByWallet(wid, query);
+      for (const auto& tx : rows) {
+        int id = tx.value("id", 0);
+        if (id > 0 && !seenIds.insert(id).second)  // khử trùng khi đã gặp id
+          continue;
+        rowsAll.push_back(Row{
+          id,
+          tx.value("sourceWalletId", -1),
+          tx.value("destinationWalletId", -1),
+          tx.value("amount", 0.0)
+        });
+      }
+    }
+
+    std::sort(rowsAll.begin(), rowsAll.end(),
+              [](const Row& a, const Row& b){ return a.id > b.id; });
+
+    if (rowsAll.empty()) {
+      utils::MessageHandler::logMessage("Không có giao dịch nào.");
+      utils::input::pauseInput();
+      return;
+    }
+
+    printHeader();
+    int no = 1;
+    for (const auto& r : rowsAll) {
+      std::ostringstream amtss; amtss << std::fixed << std::setprecision(2) << r.amt;
+      std::ostringstream line;
+      line << "| " << vnconsole::pad_left(std::to_string(no++), W_STT)
+           << " | " << vnconsole::pad_right(fullNameOfWallet(r.src), W_FROM)
+           << " | " << vnconsole::pad_right(fullNameOfWallet(r.dst), W_TO)
+           << " | " << vnconsole::pad_left(amtss.str(), W_AMT)
+           << " |";
+      utils::MessageHandler::logMessage(line.str());
+    }
+    printFooter();
+    utils::input::pauseInput();
+    return;
+  }
+
+  // ================== CHẾ ĐỘ 1 VÍ ==================
+  if (!utils::validation::isPositiveNumber(key)) {
+    utils::MessageHandler::logError("Wallet ID không hợp lệ!");
+    utils::input::pauseInput();
+    return;
+  }
+  int walletId = std::stoi(key);
+
+  auto rows = history.queryByWallet(walletId, query);
+  std::sort(rows.begin(), rows.end(),
+            [](const auto& a, const auto& b){ return a.value("id",0) > b.value("id",0); });
+
+  if (rows.empty()) {
+    utils::MessageHandler::logMessage("Không có giao dịch nào.");
+    utils::input::pauseInput();
+    return;
+  }
+
+  printHeader();
+
+  int stt = 1;
+  for (const auto& tx : rows) {
+    int    src = tx.value("sourceWalletId", -1);
+    int    dst = tx.value("destinationWalletId", -1);
+    double amt = tx.value("amount", 0.0);
+
+    std::ostringstream amtss; amtss << std::fixed << std::setprecision(2) << amt;
+
+    std::ostringstream line;
+    line << "| " << vnconsole::pad_left(std::to_string(stt++), W_STT)
+         << " | " << vnconsole::pad_right(fullNameOfWallet(src), W_FROM)
+         << " | " << vnconsole::pad_right(fullNameOfWallet(dst), W_TO)
+         << " | " << vnconsole::pad_left(amtss.str(), W_AMT)
+         << " |";
+    utils::MessageHandler::logMessage(line.str());
+  }
+
+  printFooter();
+
+  // Lấy SỐ DƯ HIỆN TẠI từ service
+  double currentBalance = 0.0;
+  bool found = false;
+  for (const auto& w : controllers::WalletController::getAllWallets()) {
+    if (w.getId() == walletId) {           // đổi getter cho khớp model nếu cần
+      currentBalance = w.getPoint();       // getter point hiện có
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    utils::MessageHandler::logError("Không tìm thấy ví!");
+  } else {
+    std::ostringstream balanceLine;
+    balanceLine << "Số dư hiện tại của ví [Wallet ID: "
+                << walletId <<"]: "
+                << std::fixed << std::setprecision(2) << currentBalance;
+    utils::MessageHandler::logMessage(balanceLine.str());
+  }
+
+  utils::input::pauseInput();
 }
 
 /**

--- a/src/views/CustomerView.cpp
+++ b/src/views/CustomerView.cpp
@@ -145,18 +145,39 @@ void CustomerView::handleTransferPoints() {
 }
 
 /**
- * @brief Hiển thị lịch sử giao dịch của khách hàng.
- *
- * Mục đích:
- *   Cho phép khách hàng xem các giao dịch đã thực hiện.
+ * @brief Hiển thị lịch sử giao dịch của ví người dùng (Customer).
  *
  * Input:
- *   - Không có tham số đầu vào.
+ *  - Wallet ID do người dùng nhập từ bàn phím.
+ *    + Chỉ được phép nhập số dương.
+ *    + Hệ thống kiểm tra ví có thuộc quyền sở hữu của user hiện tại hay không.
  *
  * Output:
- *   - Không trả về giá trị.
- *   - In thông tin lịch sử giao dịch ra màn hình.
+ *  - Hiển thị bảng lịch sử giao dịch của ví đó với các cột:
+ *      [STT]  [Biến động +/-Số điểm]  [Mô tả (người chuyển/nhận)].
+ *  - Hiển thị thêm số dư hiện tại của ví.
+ *  - Nếu không có giao dịch hoặc Wallet ID không hợp lệ → báo lỗi/thông báo.
+ *
+ * Thủ tục xử lý:
+ *  1. Hiển thị tiêu đề "LỊCH SỬ GIAO DỊCH".
+ *  2. Yêu cầu người dùng nhập Wallet ID.
+ *  3. Kiểm tra:
+ *      - Nếu ID không hợp lệ → báo lỗi và dừng.
+ *      - Nếu ví không thuộc về user hiện tại → báo lỗi và dừng.
+ *  4. Tạo truy vấn (TxQuery) để lấy danh sách giao dịch của ví.
+ *  5. Sắp xếp các giao dịch theo ID giảm dần.
+ *  6. Nếu không có giao dịch → thông báo và dừng.
+ *  7. Nếu có:
+ *      - In bảng với header (STT | Biến động | Mô tả).
+ *      - Duyệt từng giao dịch:
+ *          + Xác định ví là người gửi hay nhận.
+ *          + Tính biến động số điểm (+/-).
+ *          + Tạo mô tả ("Nhận điểm từ X" hoặc "Chuyển điểm đến Y").
+ *          + In ra một dòng của bảng.
+ *  8. In footer và gọi hàm lấy số dư hiện tại của ví.
+ *  9. Tạm dừng, chờ người dùng nhấn phím tiếp tục.
  */
+
 void CustomerView::handleViewTransactionHistory() {
   utils::MessageHandler::logMessage("+-------------------------------------------------------------+");
   utils::MessageHandler::logMessage("|                  LỊCH SỬ GIAO DỊCH                          |");

--- a/src/views/CustomerView.cpp
+++ b/src/views/CustomerView.cpp
@@ -235,7 +235,6 @@ void CustomerView::handleViewTransactionHistory() {
     int    src = tx.value("sourceWalletId", -1);
     int    dst = tx.value("destinationWalletId", -1);
     double amt = tx.value("amount", 0.0);
-    int    st  = tx.value("status", -1); // 1=Thành công
 
     // ±amount
     std::ostringstream amtss; amtss << std::fixed << std::setprecision(2) << amt;


### PR DESCRIPTION
- Thêm chức năng: tra cứu lịch sử giao dịch cho admin và customer:
Đối với admin: có chức năng xem tất cả giao dịch trên hệ thống và xem của từng ví khác nhau
đối với customer: xem biến động số điểm theo từng Wallet ID
- Bổ sung file hỗ trợ hiển thị tiếng Việt cho Windown.